### PR TITLE
KP-7421 Provide the front page url to the tutorial converting script

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,11 +40,17 @@ jobs:
         uses: actions/configure-pages@v3
       - name: Create html pages from the markdown
         run: |
+          HOME_PAGE_URL=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/pages \
+            | jq -r ".html_url")
           mkdir -p _site/slides
           mkdir -p _site/tutorials
           ~/convert-single-page.sh index.md _site/index.html
           ~/convert-slides.sh slides/ _site/slides
-          ~/convert-tutorials.sh tutorials _site/tutorials
+          ~/convert-tutorials.sh tutorials _site/tutorials $HOME_PAGE_URL
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
 


### PR DESCRIPTION
This way it can be used when adding the navigation link. The URL is fetched from the GitHub API to ensure that the home page link also works in forked repositories. This should avoid missing bugs because one accidentally clicked a home page link that took them to the production (where a feature isn't broken − yet).

Preview generated by https://github.com/aajarven/Kielipankki/pull/3 available at https://aajarven.github.io/Kielipankki/tutorials/rights_and_licenses_handout.html

> **Warning**
> Before merging:
> - [ ] Deploy a [updated course-runner pod](https://github.com/CSCfi/kielipankki-actions-pipeline/pull/11) with the newest software so that the pipeline works